### PR TITLE
Add extra bindings for cluster and replication network

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -225,3 +225,9 @@ options:
     default: 6012
     type: int
     description: Listening port of the swift-account-replication-server.
+  custom-hosts-allow:
+    default: ""
+    type: string
+    description: |
+      Additional networks or hosts that should be allowed access to
+      rsync services provided by Swift. This might come handy in multi.

--- a/config.yaml
+++ b/config.yaml
@@ -229,5 +229,5 @@ options:
     default: ""
     type: string
     description: |
-      Additional networks or hosts that should be allowed access to
-      rsync services provided by Swift. This might come handy in multi.
+      Additional space delimited networks or hosts which should be allowed
+      access to rsync services provided by Swift.

--- a/hooks/swift_storage_hooks.py
+++ b/hooks/swift_storage_hooks.py
@@ -65,6 +65,7 @@ from charmhelpers.core.hookenv import (
     Hooks, UnregisteredHookError,
     config,
     log,
+    network_get,
     relation_get,
     relation_ids,
     relation_set,
@@ -273,7 +274,11 @@ def swift_storage_relation_joined(rid=None):
         log('Encryption configured and vault not ready, deferring',
             level=DEBUG)
         return
+    replication_ip = network_get('replication')
+    cluster_ip = network_get('cluster')
     rel_settings = {
+        'replication_ip': replication_ip,
+        'cluster_ip': cluster_ip,
         'region': config('region'),
         'zone': config('zone'),
         'object_port': config('object-server-port'),

--- a/lib/swift_storage_context.py
+++ b/lib/swift_storage_context.py
@@ -66,6 +66,9 @@ class RsyncContext(OSContextGenerator):
                 settings = relation_get(unit=unit, rid=rid)
                 ts = settings.get('timestamp')
                 allowed_hosts = settings.get('rsync_allowed_hosts')
+                custom_hosts = config('custom-hosts-allow')
+                if not custom_hosts = "":
+                    allowed_hosts = "%s %s" % (allowed_hosts, custom_hosts)
                 if allowed_hosts and ts:
                     if not timestamps or ts > max(timestamps):
                         ctxt['allowed_hosts'] = allowed_hosts

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,6 +22,9 @@ series:
   - bionic
   - cosmic
   - trusty
+extra-bindings:
+  replication:
+  cluster:
 provides:
   nrpe-external-master:
     interface: nrpe-external-master


### PR DESCRIPTION
Also add 'custom-hosts-allow' for rsync, mostly as a workaround
untill we are in position to generate rsync 'hosts allow' from
swift's rings.